### PR TITLE
Support DELETE body id

### DIFF
--- a/project/project_management/api/project_management_api.php
+++ b/project/project_management/api/project_management_api.php
@@ -64,8 +64,14 @@ try {
                     }
                     break;
                 case 'DELETE':
-                    $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
-                    if (!$id) sendResponse(['error' => 'ID required'], 400);
+                    $data = getRequestBody();
+                    if (!is_array($data)) {
+                        $data = [];
+                    }
+                    $id = isset($_GET['id']) && $_GET['id'] !== '' ? intval($_GET['id']) : (isset($data['id']) ? intval($data['id']) : 0);
+                    if (!$id) {
+                        sendResponse(['error' => 'ID required'], 400);
+                    }
                     $stmt = $conn->prepare("DELETE FROM projects WHERE id=?");
                     $stmt->bind_param("i", $id);
                     if ($stmt->execute()) {
@@ -119,8 +125,14 @@ try {
                     }
                     break;
                 case 'DELETE':
-                    $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
-                    if (!$id) sendResponse(['error' => 'ID required'], 400);
+                    $data = getRequestBody();
+                    if (!is_array($data)) {
+                        $data = [];
+                    }
+                    $id = isset($_GET['id']) && $_GET['id'] !== '' ? intval($_GET['id']) : (isset($data['id']) ? intval($data['id']) : 0);
+                    if (!$id) {
+                        sendResponse(['error' => 'ID required'], 400);
+                    }
                     $stmt = $conn->prepare("DELETE FROM project_tasks WHERE id=?");
                     $stmt->bind_param("i", $id);
                     if ($stmt->execute()) {


### PR DESCRIPTION
## Summary
- allow project deletion when id passed via JSON body
- allow task deletion when id passed via JSON body

## Testing
- `php -l project_management_api.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6863c80ee3cc83259a36ad58c4f5cd1d