### PR TITLE
Reorder dashboard tabs

### DIFF
--- a/project/dashboard6.php
+++ b/project/dashboard6.php
@@ -85,14 +85,14 @@ $incidents = fetch_incidents($conn);
       <li class="nav-item" role="presentation">
         <button class="nav-link" id="dailytask-tab" data-bs-toggle="tab" data-bs-target="#dailytask" type="button" role="tab">Daily Task Tracking</button>
       </li>
-      <li class="nav-item" role="presentation" id="usermanagement-main-tab-li" style="display:none;">
-        <button class="nav-link" id="usermanagement-main-tab" data-bs-toggle="tab" data-bs-target="#usermanagement-main" type="button" role="tab">User Management</button>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" id="projecttask-tab" data-bs-toggle="tab" data-bs-target="#projecttask" type="button" role="tab">Project and Task Management</button>
       </li>
       <li class="nav-item" role="presentation">
         <a class="nav-link" id="reports-tab" href="report.php" target="_blank" role="tab">Reports</a>
       </li>
-      <li class="nav-item" role="presentation">
-        <button class="nav-link" id="projecttask-tab" data-bs-toggle="tab" data-bs-target="#projecttask" type="button" role="tab">Project and Task Management</button>
+      <li class="nav-item" role="presentation" id="usermanagement-main-tab-li" style="display:none;">
+        <button class="nav-link" id="usermanagement-main-tab" data-bs-toggle="tab" data-bs-target="#usermanagement-main" type="button" role="tab">User Management</button>
       </li>
     </ul>
     <div class="tab-content" id="dashboardTabsContent">


### PR DESCRIPTION
## Summary
- reorder dashboard6 main tabs to match desired layout

## Testing
- `php -l project/dashboard6.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6863d8c8780c8325b6641010c5c9c24e