### PR TITLE
Fix JS user dropdown display bug

### DIFF
--- a/project/assets/dashboard6.js.php
+++ b/project/assets/dashboard6.js.php
@@ -3420,7 +3420,7 @@ require_once __DIR__.'/../includes/config.php';
       select.append('<option value="">Select user...</option>');
       if (res && res.length) {
         res.forEach(function(user) {
-          select.append('<option value="' + user.id + '">' + user.username + ' ( + user.role + ')</option>');
+          select.append('<option value="' + user.id + '">' + user.username + ' (' + user.role + ')</option>');
         });
       }
       // Enhance with Select2 if available


### PR DESCRIPTION
## Summary
- fix incorrect dropdown option string interpolation

## Testing
- `php -l project/assets/dashboard6.js.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6863dda70dd08325825b2d76fc37e6cf