### PR TITLE
Fix CSRF token not sent in daily task form

### DIFF
--- a/project/assets/dashboard6.js.php
+++ b/project/assets/dashboard6.js.php
@@ -997,7 +997,7 @@ require_once __DIR__.'/../includes/config.php';
       $(document).on('click', '.delete-dailytask-btn', function() {
         if (!confirm('Are you sure you want to delete this task?')) return;
         var id = $(this).data('id');
-        $.post('edit_daily_task.php', { delete: 1, id: id }, function(resp) {
+        $.post('edit_daily_task.php', { delete: 1, id: id, csrf_token: '<?php echo $_SESSION['csrf_token']; ?>' }, function(resp) {
           if (resp.trim() === 'success') {
             if ($('.datatable-dailytask').length) $('.datatable-dailytask').DataTable().ajax.reload(null, false);
           } else {

--- a/project/dashboard6.php
+++ b/project/dashboard6.php
@@ -805,6 +805,7 @@ $incidents = fetch_incidents($conn);
         <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <form id="editDailyTaskForm">
+        <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token']; ?>">
         <div class="modal-body">
           <input type="hidden" id="edit-dailytask-id" name="id">
           <div class="mb-3">


### PR DESCRIPTION
## Summary
- ensure CSRF token is included when editing daily tasks
- add token to AJAX delete request

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863df0108408325ae963eca33b19d4b