### PR TITLE
Add limit to daily tasks summary query

### DIFF
--- a/project/daily_tasks_summary.php
+++ b/project/daily_tasks_summary.php
@@ -26,7 +26,7 @@ $completion_rate = $total > 0 ? round(($completed / $total) * 100, 1) : 0;
 
 // Get latest 5 tasks
 $latest = [];
-$res = $conn->query("SELECT datetime, task_description, status, assigned_to, percent_completed, shift, due_date, priority, task_category FROM daily_tasks ORDER BY datetime DESC");
+$res = $conn->query("SELECT datetime, task_description, status, assigned_to, percent_completed, shift, due_date, priority, task_category FROM daily_tasks ORDER BY datetime DESC LIMIT 5");
 while ($row = $res->fetch_assoc()) {
   // Format datetime for display (short date)
   $dt = date('M j, Y', strtotime($row['datetime']));


### PR DESCRIPTION
## Summary
- constrain daily task summary query to return only 5 tasks

## Testing
- `vendor/bin/php-cs-fixer fix --dry-run` *(fails: no such file)*
- `php -d variables_order=EGPCS vendor/bin/phpunit` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6864ed5ebbc4832595ee68e49679f62d