### PR TITLE
Fix parameter type string in daily task binding

### DIFF
--- a/project/edit_daily_task.php
+++ b/project/edit_daily_task.php
@@ -57,7 +57,7 @@ if ($id) {
   // Allow admin to edit all fields
   if ($_SESSION['role'] === 'admin') {
     $stmt = $conn->prepare("UPDATE daily_tasks SET datetime=?, shift=?, task_description=?, assigned_to=?, status=?, percent_completed=?, comment=?, project_id=?, due_date=?, priority=?, task_category=?, estimated_time=?, time_spent=? WHERE id=?");
-    $stmt->bind_param('sssssisisssiii', $datetime, $shift, $task_description, $assigned_to, $status, $percent_completed, $comment, $project_id, $due_date, $priority, $task_category, $estimated_time, $time_spent, $id);
+    $stmt->bind_param('sssssissssiii', $datetime, $shift, $task_description, $assigned_to, $status, $percent_completed, $comment, $project_id, $due_date, $priority, $task_category, $estimated_time, $time_spent, $id);
     $stmt->execute();
     echo $stmt->affected_rows !== false ? 'success' : 'fail';
   }
@@ -69,7 +69,7 @@ if ($id) {
   else if ($current_user === $created_by) {
     // Creator: can update all fields (9 fields + id = 10 params)
     $stmt = $conn->prepare("UPDATE daily_tasks SET datetime=?, shift=?, task_description=?, assigned_to=?, status=?, percent_completed=?, comment=?, project_id=?, due_date=?, priority=?, task_category=?, estimated_time=?, time_spent=? WHERE id=?");
-    $stmt->bind_param('sssssisisssiii', $datetime, $shift, $task_description, $assigned_to, $status, $percent_completed, $comment, $project_id, $due_date, $priority, $task_category, $estimated_time, $time_spent, $id);
+    $stmt->bind_param('sssssissssiii', $datetime, $shift, $task_description, $assigned_to, $status, $percent_completed, $comment, $project_id, $due_date, $priority, $task_category, $estimated_time, $time_spent, $id);
     $stmt->execute();
     echo $stmt->affected_rows !== false ? 'success' : 'fail';
   } else if ($current_user === $assigned_to_db) {
@@ -83,7 +83,7 @@ if ($id) {
   // Insert: set created_by to current user (9 fields + created_by = 10 params)
   $created_by = $current_user;
   $stmt = $conn->prepare("INSERT INTO daily_tasks (created_by, datetime, shift, task_description, assigned_to, status, percent_completed, comment, project_id, due_date, priority, task_category, estimated_time, time_spent) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
-  $stmt->bind_param('ssssssisisssii', $created_by, $datetime, $shift, $task_description, $assigned_to, $status, $percent_completed, $comment, $project_id, $due_date, $priority, $task_category, $estimated_time, $time_spent);
+  $stmt->bind_param('sssssissssiii', $created_by, $datetime, $shift, $task_description, $assigned_to, $status, $percent_completed, $comment, $project_id, $due_date, $priority, $task_category, $estimated_time, $time_spent);
   $stmt->execute();
   echo $stmt->affected_rows ? 'success' : 'fail';
 }


### PR DESCRIPTION
## Summary
- adjust parameter type string in `edit_daily_task.php` for update and insert operations

## Testing
- `vendor/bin/php-cs-fixer fix --dry-run` *(fails: No such file or directory)*
- `php -d variables_order=EGPCS vendor/bin/phpunit` *(fails: php command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864ed253afc83259976aab4580de8f1