### PR TITLE
Fix edit task modal JS error

### DIFF
--- a/project/assets/dashboard6.js.php
+++ b/project/assets/dashboard6.js.php
@@ -1038,7 +1038,7 @@ require_once __DIR__.'/../includes/config.php';
       // When opening the modal for edit/add
       document.addEventListener('click', function(event) {
         if (event.target.classList.contains('edit-dailytask-btn')) {
-          // ... your existing code ...
+          const btn = event.target;
           // Prefill dropdown with users and select the current one
           loadUsersDropdown(btn.getAttribute('data-assigned_to'));
           // ... rest of your code ...


### PR DESCRIPTION
## Summary
- fix undefined variable when opening edit modal

## Testing
- `php -d variables_order=EGPCS vendor/bin/phpunit` *(fails: command not found)*
- `vendor/bin/php-cs-fixer fix --dry-run` *(fails: no such file)*

------
https://chatgpt.com/codex/tasks/task_e_68650fbd76ac832595f70d0129e2b1dc