### PR TITLE
Fix project/task editing

### DIFF
--- a/project/assets/dashboard6.js.php
+++ b/project/assets/dashboard6.js.php
@@ -3478,7 +3478,8 @@ require_once __DIR__.'/../includes/config.php';
     };
     $.ajax({
       url: 'project_management/api/project_management_api.php?endpoint=projects',
-      method: 'PUT',
+      method: 'POST',
+      headers: { 'X-HTTP-Method-Override': 'PUT' },
       contentType: 'application/json',
       data: JSON.stringify(data),
       success: function(res) {
@@ -3496,7 +3497,8 @@ require_once __DIR__.'/../includes/config.php';
     const id = $(this).data('id');
     $.ajax({
       url: 'project_management/api/project_management_api.php?endpoint=projects',
-      method: 'DELETE',
+      method: 'POST',
+      headers: { 'X-HTTP-Method-Override': 'DELETE' },
       contentType: 'application/json',
       data: JSON.stringify({ id }),
       success: function(res) {
@@ -3553,7 +3555,8 @@ require_once __DIR__.'/../includes/config.php';
     };
     $.ajax({
       url: 'project_management/api/project_management_api.php?endpoint=tasks',
-      method: 'PUT',
+      method: 'POST',
+      headers: { 'X-HTTP-Method-Override': 'PUT' },
       contentType: 'application/json',
       data: JSON.stringify(data),
       success: function(res) {
@@ -3571,7 +3574,8 @@ require_once __DIR__.'/../includes/config.php';
     const id = $(this).data('id');
     $.ajax({
       url: 'project_management/api/project_management_api.php?endpoint=tasks',
-      method: 'DELETE',
+      method: 'POST',
+      headers: { 'X-HTTP-Method-Override': 'DELETE' },
       contentType: 'application/json',
       data: JSON.stringify({ id }),
       success: function(res) {

--- a/project/project_management/api/project_management_api.php
+++ b/project/project_management/api/project_management_api.php
@@ -9,12 +9,21 @@ if (!isset($_SESSION['user_id'])) {
 }
 
 $method = $_SERVER['REQUEST_METHOD'];
+// Allow method override via header or POST parameter for clients that cannot
+// send PUT/DELETE requests directly
+if ($method === 'POST') {
+    if (isset($_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'])) {
+        $method = strtoupper($_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE']);
+    } elseif (isset($_POST['_method'])) {
+        $method = strtoupper($_POST['_method']);
+    }
+}
 $endpoint = isset($_GET['endpoint']) ? $_GET['endpoint'] : '';
 
 header('Content-Type: application/json');
 header('Access-Control-Allow-Origin: *');
 header('Access-Control-Allow-Methods: GET, POST, PUT, DELETE');
-header('Access-Control-Allow-Headers: Content-Type');
+header('Access-Control-Allow-Headers: Content-Type, X-HTTP-Method-Override');
 
 function getRequestBody() {
     return json_decode(file_get_contents('php://input'), true);


### PR DESCRIPTION
## Summary
- allow POST method override in project management API
- handle PUT/DELETE via X-HTTP-Method-Override headers in dashboard JS

## Testing
- `php -d variables_order=EGPCS vendor/bin/phpunit` *(fails: command not found)*
- `vendor/bin/php-cs-fixer fix --dry-run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865168960a48325938e972a3aad172e