### PR TITLE
Improve manager notifications handling

### DIFF
--- a/project/assets/dashboard6.js.php
+++ b/project/assets/dashboard6.js.php
@@ -7,8 +7,11 @@ require_once __DIR__.'/../includes/config.php';
       // Get user role from PHP session
       const userRole = '<?php echo $_SESSION['role']; ?>';
       if (userRole !== 'readonly') {
-        fetch('manager_notifications.php').then(r => r.json()).then(d => {
-          if (d.count && d.count > 0) {
+        fetch('manager_notifications.php').then(r => {
+          if (!r.ok) return null;
+          return r.json();
+        }).then(d => {
+          if (d && d.count && d.count > 0) {
             const toast = document.createElement('div');
             toast.className = 'toast align-items-center text-bg-primary position-fixed top-0 end-0 m-3';
             toast.innerHTML = '<div class="d-flex"><div class="toast-body">You have '+d.count+' new task comments.</div><button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"></button></div>';

--- a/project/manager_notifications.php
+++ b/project/manager_notifications.php
@@ -1,7 +1,9 @@
 <?php
 require_once 'includes/config.php';
+
 if (!isset($_SESSION['user_id'])) {
     http_response_code(401);
+    echo json_encode(['error' => 'Unauthorized']);
     exit;
 }
 
@@ -11,6 +13,11 @@ $username = $_SESSION['username'];
 // Count unseen updates for tasks created by this user
 $sql = "SELECT COUNT(*) FROM task_updates tu JOIN daily_tasks dt ON tu.task_type='daily' AND tu.task_id=dt.id WHERE dt.created_by=? AND tu.manager_seen=0 AND tu.user_id<>?";
 $stmt = $conn->prepare($sql);
+if (!$stmt) {
+    http_response_code(500);
+    echo json_encode(['error' => $conn->error]);
+    exit;
+}
 $stmt->bind_param('si', $username, $userId);
 $stmt->execute();
 $stmt->bind_result($countDaily);
@@ -19,6 +26,11 @@ $stmt->close();
 
 $sql = "SELECT COUNT(*) FROM task_updates tu JOIN project_tasks pt ON tu.task_type='project' AND tu.task_id=pt.id JOIN projects p ON pt.project_id=p.id WHERE p.created_by=? AND tu.manager_seen=0 AND tu.user_id<>?";
 $stmt = $conn->prepare($sql);
+if (!$stmt) {
+    http_response_code(500);
+    echo json_encode(['error' => $conn->error]);
+    exit;
+}
 $stmt->bind_param('ii', $userId, $userId);
 $stmt->execute();
 $stmt->bind_result($countProject);
@@ -30,11 +42,21 @@ $total = (int)$countDaily + (int)$countProject;
 // Mark these updates as seen
 if ($total > 0) {
     $stmt = $conn->prepare("UPDATE task_updates tu JOIN daily_tasks dt ON tu.task_type='daily' AND tu.task_id=dt.id SET tu.manager_seen=1 WHERE dt.created_by=? AND tu.manager_seen=0 AND tu.user_id<>?");
+    if (!$stmt) {
+        http_response_code(500);
+        echo json_encode(['error' => $conn->error]);
+        exit;
+    }
     $stmt->bind_param('si', $username, $userId);
     $stmt->execute();
     $stmt->close();
 
     $stmt = $conn->prepare("UPDATE task_updates tu JOIN project_tasks pt ON tu.task_type='project' AND tu.task_id=pt.id JOIN projects p ON pt.project_id=p.id SET tu.manager_seen=1 WHERE p.created_by=? AND tu.manager_seen=0 AND tu.user_id<>?");
+    if (!$stmt) {
+        http_response_code(500);
+        echo json_encode(['error' => $conn->error]);
+        exit;
+    }
     $stmt->bind_param('ii', $userId, $userId);
     $stmt->execute();
     $stmt->close();

--- a/project/team_task_dashboard.php
+++ b/project/team_task_dashboard.php
@@ -92,8 +92,11 @@ function fetchUpdates(type,id){
     });
 }
 $(function(){
-    fetch('manager_notifications.php').then(r=>r.json()).then(d=>{
-        if(d.count && d.count>0){
+    fetch('manager_notifications.php').then(r=>{
+        if(!r.ok) return null;
+        return r.json();
+    }).then(d=>{
+        if(d && d.count && d.count>0){
             const toast=document.createElement('div');
             toast.className='toast align-items-center text-bg-primary position-fixed top-0 end-0 m-3';
             toast.innerHTML='<div class="d-flex"><div class="toast-body">You have '+d.count+' new task comments.</div><button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"></button></div>';


### PR DESCRIPTION
## Summary
- add auth errors and DB error checks in `manager_notifications.php`
- handle failed fetches gracefully in dashboard scripts

## Testing
- `php -d variables_order=EGPCS vendor/bin/phpunit` *(fails: php not installed)*
- `vendor/bin/php-cs-fixer fix --dry-run` *(fails: php-cs-fixer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68651a8f1234832599fff7865dcda653