### PR TITLE
Fix manager notifications include path

### DIFF
--- a/project/manager_notifications.php
+++ b/project/manager_notifications.php
@@ -1,5 +1,9 @@
 <?php
-require_once 'includes/config.php';
+// Use absolute path to ensure the config file is loaded correctly regardless
+// of the current working directory. In some environments the working directory
+// may differ from the script location which could lead to a failed include and
+// consequently a 500 error.
+require_once __DIR__ . '/includes/config.php';
 
 header('Content-Type: application/json');
 mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);


### PR DESCRIPTION
## Summary
- fix include path in manager notifications

## Testing
- `vendor/bin/php-cs-fixer fix --dry-run` *(fails: No such file or directory)*
- `php -d variables_order=EGPCS vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68652648726883259a44c17e33cef3a3