### PR TITLE
Restrict dashboard access to admin

### DIFF
--- a/project/dashboard6.php
+++ b/project/dashboard6.php
@@ -12,6 +12,13 @@ if (!isset($_SESSION['user_id'])) {
     exit();
 }
 
+// Allow only admin users to access this page
+if (($_SESSION['role'] ?? '') !== 'admin') {
+    // Redirect non-admin users to their dashboard
+    header('Location: ?p=team_task_dashboard.php');
+    exit();
+}
+
 
 // --- Reporting: Get all tables, with hide config ---
 $hiddenTables = [


### PR DESCRIPTION
## Summary
- restrict `dashboard6.php` to admin role by redirecting non-admin users to the team task dashboard

## Testing
- `php -d variables_order=EGPCS vendor/bin/phpunit` *(fails: command not found)*
- `vendor/bin/php-cs-fixer fix --dry-run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865273702c4832593c362c53405eb6a