### PR TITLE
Handle DB errors gracefully in manager notifications

### DIFF
--- a/project/manager_notifications.php
+++ b/project/manager_notifications.php
@@ -52,7 +52,8 @@ try {
 
     echo json_encode(['count' => $total]);
 } catch (Exception $e) {
-    error_log($e->getMessage());
-    http_response_code(500);
-    echo json_encode(['error' => 'Database error']);
+    // Log the underlying failure for troubleshooting but return an empty count
+    // so the dashboard does not break if the database query fails.
+    error_log('manager_notifications.php error: ' . $e->getMessage());
+    echo json_encode(['count' => 0]);
 }


### PR DESCRIPTION
## Summary
- avoid 500 responses in `manager_notifications.php` by returning an empty count on failure

## Testing
- `vendor/bin/php-cs-fixer fix --dry-run` *(fails: No such file or directory)*
- `php -d variables_order=EGPCS vendor/bin/phpunit` *(fails: php: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68652b4f1b20832580f4837e72ad8068