### PR TITLE
Fix task_updates.php include path

### DIFF
--- a/project/task_updates.php
+++ b/project/task_updates.php
@@ -1,5 +1,9 @@
 <?php
-require_once 'includes/config.php';
+// Use absolute path to ensure the config file is loaded correctly regardless
+// of the current working directory. In some environments the working directory
+// may differ from the script location which could lead to a failed include and
+// consequently a 500 error.
+require_once __DIR__ . '/includes/config.php';
 
 header('Content-Type: application/json');
 mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);


### PR DESCRIPTION
## Summary
- load config with an absolute path in `task_updates.php`

## Testing
- `php -d variables_order=EGPCS vendor/bin/phpunit` *(fails: command not found)*
- `vendor/bin/php-cs-fixer fix --dry-run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68652f98a7308325a2d1cf1d94af3f98