### PR TITLE
Show task update history for managers

### DIFF
--- a/project/assets/dashboard6.css
+++ b/project/assets/dashboard6.css
@@ -3,8 +3,8 @@
     .card-header { background: #23272b !important; color: #f8f9fa; border-bottom: 1px solid #343a40; }
     .user-info {
       position: fixed;
-      top: 20px;
-      right: 20px;
+      bottom: 20px;
+      left: 20px;
       background: #23272b;
       padding: 10px 20px;
       border-radius: 8px;

--- a/project/assets/dashboard6.js.php
+++ b/project/assets/dashboard6.js.php
@@ -218,6 +218,9 @@ require_once __DIR__.'/../includes/config.php';
           { "data": "due_date" },
           { "data": "priority" },
           { "data": "comment" },
+          { data: null, orderable: false, render: function(data, type, row) {
+              return `<button class="btn btn-sm btn-info view-updates-btn" data-type="daily" data-id="${row.id}">Updates</button>`;
+          }},
           { "data": null, "orderable": false, "render": function(data, type, row) {
               if (userRole !== 'admin' && userRole !== 'operator') return '';
               return `
@@ -3321,6 +3324,9 @@ require_once __DIR__.'/../includes/config.php';
             } },
             { data: 'created_at' },
             { data: null, orderable: false, render: function(data, type, row) {
+                return `<button class="btn btn-sm btn-info view-updates-btn" data-type="project" data-id="${row.id}">Updates</button>`;
+            }},
+            { data: null, orderable: false, render: function(data, type, row) {
                 if (userRole !== 'admin' && userRole !== 'operator') return '';
                 return `
                   <button class="btn btn-sm btn-warning edit-projecttask-btn"
@@ -3623,5 +3629,20 @@ require_once __DIR__.'/../includes/config.php';
     console.log('[DEBUG] Select button clicked. selectedProjectId:', selectedProjectId);
     $('#projectTasksTable').DataTable().ajax.reload(function() {
       console.log('[DEBUG] Project Tasks DataTable reloaded.');
+    });
+  });
+
+  $(document).on('click', '.view-updates-btn', function() {
+    const id = $(this).data('id');
+    const type = $(this).data('type');
+    $.getJSON('task_updates.php', { task_type: type, task_id: id }, function(res) {
+      const list = $('#updatesList').empty();
+      if (res.updates) {
+        res.updates.forEach(function(u) {
+          list.append(`<li class="list-group-item bg-secondary">${u.username}: ${u.comment} (${u.progress}% ${u.status})</li>`);
+        });
+      }
+      var modal = new bootstrap.Modal(document.getElementById('updatesModal'));
+      modal.show();
     });
   });

--- a/project/dashboard6.php
+++ b/project/dashboard6.php
@@ -493,6 +493,7 @@ $incidents = fetch_incidents($conn);
                       <th>Due Date</th>
                       <th>Priority</th>
                       <th>Comment</th>
+                      <th>Updates</th>
                       <th>Action</th>
                     </tr>
                   </thead>
@@ -721,6 +722,7 @@ $incidents = fetch_incidents($conn);
                       <th>Due Date</th>
                       <th>Status</th>
                       <th>Created At</th>
+                      <th>Updates</th>
                       <th>Action</th>
                     </tr>
                   </thead>
@@ -947,6 +949,24 @@ $incidents = fetch_incidents($conn);
           <button type="button" class="btn btn-primary" id="saveProjectTaskBtn">Save Changes</button>
         </div>
       </form>
+    </div>
+  </div>
+</div>
+
+<!-- Task Updates Modal -->
+<div class="modal fade" id="updatesModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content bg-dark text-light">
+      <div class="modal-header">
+        <h5 class="modal-title">Task Updates</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <ul class="list-group mb-3" id="updatesList"></ul>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- move user avatar to bottom left so toasts aren't hidden
- allow managers to view task update history on dashboard
- show Updates column in project and daily task tables

## Testing
- `php -d variables_order=EGPCS vendor/bin/phpunit` *(fails: command not found)*
- `vendor/bin/php-cs-fixer fix --dry-run` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6866665e093c8325be43d0aa5153717a