### PR TITLE
Show task update history for managers

### DIFF
--- a/project/assets/dashboard6.css
+++ b/project/assets/dashboard6.css
@@ -3,8 +3,8 @@
     .card-header { background: #23272b !important; color: #f8f9fa; border-bottom: 1px solid #343a40; }
     .user-info {
       position: fixed;
-      top: 20px;
-      right: 20px;
+      bottom: 20px;
+      left: 20px;
       background: #23272b;
       padding: 10px 20px;
       border-radius: 8px;
@@ -308,4 +308,9 @@
     .dataTables_paginate .pagination .paginate_button .page-link:focus {
       box-shadow: 0 0 0 2px #f6ad5555;
       outline: none;
+    }
+
+    #updateList, #updatesList {
+      max-height: 200px;
+      overflow-y: auto;
     }

--- a/project/assets/dashboard6.js.php
+++ b/project/assets/dashboard6.js.php
@@ -3,9 +3,11 @@ header("Content-Type: application/javascript");
 require_once __DIR__.'/../includes/config.php';
 ?>
     var selectedProjectId = null;
+    var currentTask = {id:0, type:''};
     document.addEventListener('DOMContentLoaded', function () {
-      // Get user role from PHP session
+      // Get user role and id from PHP session
       const userRole = '<?php echo $_SESSION['role']; ?>';
+      const currentUserId = <?php echo (int)$_SESSION['user_id']; ?>;
       if (userRole !== 'readonly') {
         fetch('manager_notifications.php').then(r => r.json()).then(d => {
           if (d.count && d.count > 0) {
@@ -218,6 +220,9 @@ require_once __DIR__.'/../includes/config.php';
           { "data": "due_date" },
           { "data": "priority" },
           { "data": "comment" },
+          { data: null, orderable: false, render: function(data, type, row) {
+              return `<button class="btn btn-sm btn-info view-updates-btn" data-type="daily" data-id="${row.id}">Updates</button>`;
+          }},
           { "data": null, "orderable": false, "render": function(data, type, row) {
               if (userRole !== 'admin' && userRole !== 'operator') return '';
               return `
@@ -3321,6 +3326,9 @@ require_once __DIR__.'/../includes/config.php';
             } },
             { data: 'created_at' },
             { data: null, orderable: false, render: function(data, type, row) {
+                return `<button class="btn btn-sm btn-info view-updates-btn" data-type="project" data-id="${row.id}">Updates</button>`;
+            }},
+            { data: null, orderable: false, render: function(data, type, row) {
                 if (userRole !== 'admin' && userRole !== 'operator') return '';
                 return `
                   <button class="btn btn-sm btn-warning edit-projecttask-btn"
@@ -3623,5 +3631,50 @@ require_once __DIR__.'/../includes/config.php';
     console.log('[DEBUG] Select button clicked. selectedProjectId:', selectedProjectId);
     $('#projectTasksTable').DataTable().ajax.reload(function() {
       console.log('[DEBUG] Project Tasks DataTable reloaded.');
+    });
+  });
+
+  function fetchTaskUpdates(type, id) {
+    $.getJSON('task_updates.php', { task_type: type, task_id: id }, function(res) {
+      const list = $('#updatesList').empty();
+      if (res.updates) {
+        res.updates.forEach(function(u) {
+          const del = u.user_id == currentUserId ?
+            `<button class="btn btn-sm btn-danger delete-update-btn float-end" data-update-id="${u.id}">Delete</button>` : '';
+          list.append(`<li class="list-group-item bg-secondary">${u.username}: ${u.comment} (${u.progress}% ${u.status}) ${del}</li>`);
+        });
+      }
+    });
+  }
+
+  $(document).on('click', '.view-updates-btn', function() {
+    const id = $(this).data('id');
+    const type = $(this).data('type');
+    currentTask = {id:id, type:type};
+    fetchTaskUpdates(type, id);
+    var modal = new bootstrap.Modal(document.getElementById('updatesModal'));
+    modal.show();
+  });
+
+  $(document).on('click', '#managerSaveUpdate', function() {
+    const comment = $('#managerComment').val();
+    $.ajax({
+      url: 'task_updates.php?task_type=' + currentTask.type + '&task_id=' + currentTask.id,
+      method: 'POST',
+      data: JSON.stringify({ comment }),
+      contentType: 'application/json'
+    }).done(function() {
+      $('#managerComment').val('');
+      fetchTaskUpdates(currentTask.type, currentTask.id);
+    });
+  });
+
+  $(document).on('click', '.delete-update-btn', function() {
+    const updateId = $(this).data('update-id');
+    $.ajax({
+      url: 'task_updates.php?task_type=' + currentTask.type + '&task_id=' + currentTask.id + '&update_id=' + updateId,
+      method: 'DELETE'
+    }).done(function() {
+      fetchTaskUpdates(currentTask.type, currentTask.id);
     });
   });

--- a/project/dashboard6.php
+++ b/project/dashboard6.php
@@ -493,6 +493,7 @@ $incidents = fetch_incidents($conn);
                       <th>Due Date</th>
                       <th>Priority</th>
                       <th>Comment</th>
+                      <th>Updates</th>
                       <th>Action</th>
                     </tr>
                   </thead>
@@ -721,6 +722,7 @@ $incidents = fetch_incidents($conn);
                       <th>Due Date</th>
                       <th>Status</th>
                       <th>Created At</th>
+                      <th>Updates</th>
                       <th>Action</th>
                     </tr>
                   </thead>
@@ -947,6 +949,29 @@ $incidents = fetch_incidents($conn);
           <button type="button" class="btn btn-primary" id="saveProjectTaskBtn">Save Changes</button>
         </div>
       </form>
+    </div>
+  </div>
+</div>
+
+<!-- Task Updates Modal -->
+<div class="modal fade" id="updatesModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content bg-dark text-light">
+      <div class="modal-header">
+        <h5 class="modal-title">Task Updates</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <ul class="list-group mb-3" id="updatesList"></ul>
+        <div class="mb-3">
+          <label class="form-label">Comment</label>
+          <textarea class="form-control" id="managerComment"></textarea>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+        <button type="button" class="btn btn-primary" id="managerSaveUpdate">Save</button>
+      </div>
     </div>
   </div>
 </div>

--- a/project/task_updates.php
+++ b/project/task_updates.php
@@ -50,7 +50,7 @@ if (!$taskType || !$taskId) {
 if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     try {
         $stmt = $conn->prepare(
-            "SELECT tu.id, tu.comment, tu.progress, tu.status, tu.created_at, u.username
+            "SELECT tu.id, tu.comment, tu.progress, tu.status, tu.created_at, tu.user_id, u.username
              FROM task_updates tu
              JOIN users u ON tu.user_id=u.id
              WHERE tu.task_type=? AND tu.task_id=?
@@ -72,11 +72,35 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     exit;
 }
 
+if ($_SERVER['REQUEST_METHOD'] === 'DELETE') {
+    $updateId = intval($_GET['update_id'] ?? 0);
+    if ($updateId <= 0) {
+        http_response_code(400);
+        exit;
+    }
+    $stmt = $conn->prepare("SELECT user_id FROM task_updates WHERE id=?");
+    $stmt->bind_param('i', $updateId);
+    $stmt->execute();
+    $res = $stmt->get_result();
+    $row = $res->fetch_assoc();
+    if (!$row || (int)$row['user_id'] !== (int)$_SESSION['user_id']) {
+        http_response_code(403);
+        exit;
+    }
+    $del = $conn->prepare("DELETE FROM task_updates WHERE id=?");
+    $del->bind_param('i', $updateId);
+    $del->execute();
+    echo json_encode(['success' => true]);
+    exit;
+}
+
 // POST: add new update
 $data = json_decode(file_get_contents('php://input'), true);
 $comment = $data['comment'] ?? '';
-$progress = isset($data['progress']) ? intval($data['progress']) : 0;
-$status = $data['status'] ?? null;
+$progressProvided = array_key_exists('progress', $data);
+$statusProvided   = array_key_exists('status', $data);
+$progress = $progressProvided ? intval($data['progress']) : 0;
+$status   = $statusProvided ? $data['status'] : 'inprogress';
 $userId = $_SESSION['user_id'];
 
 try {
@@ -87,7 +111,7 @@ try {
     $stmt->bind_param('siisis', $taskType, $taskId, $userId, $comment, $progress, $status);
     $stmt->execute();
 
-    if ($status !== null) {
+    if ($statusProvided || $progressProvided) {
         if ($taskType === 'daily') {
             $update = $conn->prepare("UPDATE daily_tasks SET status=?, progress=? WHERE id=?");
             $update->bind_param('sii', $status, $progress, $taskId);

--- a/project/team_task_dashboard.php
+++ b/project/team_task_dashboard.php
@@ -83,12 +83,15 @@ if (!isset($_SESSION['user_id'])) {
 <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
 <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
 <script>
+const currentUserId = <?php echo (int)$_SESSION['user_id']; ?>;
 let currentTask = null;
 function fetchUpdates(type,id){
     $.getJSON('task_updates.php',{task_type:type,task_id:id},function(data){
         const list=$('#updateList').empty();
         data.updates.forEach(u=>{
-            list.append(`<li class="list-group-item bg-secondary">${u.username}: ${u.comment} (${u.progress}% ${u.status})</li>`);
+            const del = u.user_id == currentUserId ?
+                `<button class="btn btn-sm btn-danger delete-update-btn float-end" data-update-id="${u.id}">Delete</button>` : '';
+            list.append(`<li class="list-group-item bg-secondary">${u.username}: ${u.comment} (${u.progress}% ${u.status}) ${del}</li>`);
         });
     });
 }
@@ -130,6 +133,13 @@ $(function(){
         $.ajax({url:'task_updates.php?task_type='+currentTask.type+'&task_id='+currentTask.id,method:'POST',data:JSON.stringify(payload),contentType:'application/json'}).done(function(){
             $('#updateComment').val('');
             table.ajax.reload();
+            fetchUpdates(currentTask.type,currentTask.id);
+        });
+    });
+
+    $(document).on('click','.delete-update-btn',function(){
+        const updateId=$(this).data('update-id');
+        $.ajax({url:'task_updates.php?task_type='+currentTask.type+'&task_id='+currentTask.id+'&update_id='+updateId,method:'DELETE'}).done(function(){
             fetchUpdates(currentTask.type,currentTask.id);
         });
     });


### PR DESCRIPTION
## Summary
- move user avatar to bottom left so toasts aren't hidden
- allow managers to view task update history on dashboard
- show Updates column in project and daily task tables
- managers can add and delete task comments
- updates list scrolls and items can be removed by the poster
- fix manager comment posting

## Testing
- `php -d variables_order=EGPCS vendor/bin/phpunit` *(fails: command not found)*
- `vendor/bin/php-cs-fixer fix --dry-run` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6866665e093c8325be43d0aa5153717a