### PR TITLE
Enable manager comments in updates modal

### DIFF
--- a/project/dashboard6.php
+++ b/project/dashboard6.php
@@ -963,9 +963,14 @@ $incidents = fetch_incidents($conn);
       </div>
       <div class="modal-body">
         <ul class="list-group mb-3" id="updatesList"></ul>
+        <div class="mb-3">
+          <label class="form-label">Comment</label>
+          <textarea class="form-control" id="managerUpdateComment"></textarea>
+        </div>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+        <button type="button" class="btn btn-primary" id="saveManagerUpdate">Save</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add comment textarea and save button to updates modal
- track current task in dashboard JS
- allow manager dashboard to post new comments via `task_updates.php`

## Testing
- `php -d variables_order=EGPCS vendor/bin/phpunit` *(fails: command not found)*
- `vendor/bin/php-cs-fixer fix --dry-run` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68666f818e588325800656e81372ffde