### PR TITLE
Fix 500 error in task updates

### DIFF
--- a/project/task_updates.php
+++ b/project/task_updates.php
@@ -22,6 +22,7 @@ function ensureTaskUpdatesTable(mysqli $conn): void
         progress TINYINT UNSIGNED DEFAULT 0,
         status ENUM('pending','inprogress','completed') DEFAULT 'inprogress',
         manager_seen TINYINT(1) DEFAULT 0,
+        user_seen TINYINT(1) DEFAULT 0,
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         FOREIGN KEY (user_id) REFERENCES users(id)
     )";


### PR DESCRIPTION
## Summary
- ensure the task_updates table includes `user_seen` column

## Testing
- `php -d variables_order=EGPCS vendor/bin/phpunit` *(fails: `php` not found)*
- `vendor/bin/php-cs-fixer fix --dry-run` *(fails: no such file)*

------
https://chatgpt.com/codex/tasks/task_e_68667deadd048325ba189c178fb76f63